### PR TITLE
Toggle field type

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,15 @@ Other properties are:
 - email (`FIELD_EMAIL`)
 - url (`FIELD_URL`)
 - date/datetime/time (`FIELD_DATE`, `FIELD_DATETIME`, `FIELD_TIME`)
+- toggle/boolean (`FIELD_TOGGLE`)
 
 The following types require an `options` property. If it is an associative array, the value returned from `getFieldValues()` will be the key and not the value.
 
 - select (`FIELD_SELECT`)
 - radio (`FIELD_RADIO`)
 - checkbox (`FIELD_CHECKBOX`)
+
+A toggle/boolean type field will also use its `options` property when present, but it will default to Off/On. In case of boolean values, the values will require it's arguments in off state/on state order. Keys are ignored.
 
 #### Example
 

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Plugin name: Plugin Stem
  * Description: Not really a plugin in itself, but a starting point.
  * Author: Niklas Lindgren <nikc@iki.fi>
- * Version: 1.2.0
+ * Version: 1.3.0
  */
 namespace Plugins\Boilerplate;
 

--- a/lib/admin-actions.php
+++ b/lib/admin-actions.php
@@ -166,6 +166,10 @@ function renderField($args)
             renderCheckbox($args);
             break;
 
+        case Settings\FIELD_TOGGLE:
+            renderToggle($args);
+            break;
+
         default:
             error_log("Unknown field type: " . $args[Settings\PROP_TYPE]);
             break;
@@ -290,6 +294,31 @@ function renderCheckbox($args)
         >
 
         <?php echo $label ?></label> <?php if ($isDefault): ?>(default)<?php endif; ?><br>
+    <?php
+    endforeach;
+}
+
+function renderToggle($args) {
+    $selectedValue = !is_null($args[Settings\PROP_VALUE])
+        ? $args[Settings\PROP_VALUE]
+        : $args[Settings\PROP_DEFAULT];
+
+    $options = $args[Settings\PROP_OPTIONS] && 2 <= count($args[Settings\PROP_OPTIONS])
+        ? array_slice(array_values($args[Settings\PROP_OPTIONS]), 0, 2)
+        : array("Off", "On");
+
+    foreach ($options as $value => $label):
+        $selected = !!$value === $selectedValue;
+        $isDefault = !!$value === $args[Settings\PROP_DEFAULT];
+        $fieldValue = !!$value ? Settings\V_LITERAL_TRUE : Settings\V_LITERAL_FALSE;
+        ?>
+
+        <label><input
+            type="radio"
+            name="<?php echo getFieldName($args) ?>"
+            value="<?php echo $fieldValue ?>"
+            <?php if ($selected): ?>checked<?php endif; ?>
+        > <?php echo $label ?></label> <?php if ($isDefault): ?>(default)<?php endif; ?><br>
     <?php
     endforeach;
 }


### PR DESCRIPTION
Adds a toggle/boolean type field type. Rendering is still just a pair of radio buttons. A client-side replacement of a prettier toggle-button should be quite easy to implement.

Closes https://github.com/nikcorg/wp-plugin-stem/issues/4
